### PR TITLE
Fix schema names

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -145,7 +145,7 @@ https://example.com/stores/aisles                                     // A relat
 https://example.com/stores/aisles/c66f06fdb31b4882ad995e4d19ca7aed    // A single item within the collection.
 
 https://example.com/stores/schema                                     // A schema collection within the service.
-https://example.com/stores/schema/store.v1.schema.json                // A single item within the collection.
+https://example.com/stores/schema/com-example-store-v1.schema.json                // A single item within the collection.
 
 ```
 
@@ -174,7 +174,7 @@ Item: `https://example.com/stores/76cc758e256c438b8e49546e0102b8c8`
   "href": "https://example.com/stores/76cc758e256c438b8e49546e0102b8c8",
   "id": "76cc758e256c438b8e49546e0102b8c8",
   "template": "https://example.com/stores/{id}",
-  "schema": "https://example.com/schemas/store.v1.schema.json",
+  "schema": "https://example.com/schemas/com-example-store-v1.schema.json",
   "name": "Alpha",
   "phone": "(425) 555-1212",
   "operations": [
@@ -197,7 +197,7 @@ Representation: `https://example.com/stores/76cc758e256c438b8e49546e0102b8c8/pho
   "href": "https://example.com/stores/76cc758e256c438b8e49546e0102b8c8/phone",
   "id": "76cc758e256c438b8e49546e0102b8c8",
   "template": "https://example.com/stores/{id}/phone",
-  "schema": "https://example.com/schemas/store.v1.schema.json",
+  "schema": "https://example.com/schemas/com-example-store-v1.schema.json",
   "phone": "(425) 555-1212"
 }
 ```
@@ -213,7 +213,7 @@ Collection: `https://example.com/stores/all`
   	"href": "https://example.com/stores/76cc758e256c438b8e49546e0102b8c8",
   	"id": "76cc758e256c438b8e49546e0102b8c8",
   	"template": "https://example.com/stores/{id}",
-    "schema": "https://example.com/schemas/store.v1.schema.json",
+    "schema": "https://example.com/schemas/com-example-store-v1.schema.json",
     "name": "Alpha",
     "phone": "(425) 555-1212"
   },

--- a/guidelines.md
+++ b/guidelines.md
@@ -145,7 +145,7 @@ https://example.com/stores/aisles                                     // A relat
 https://example.com/stores/aisles/c66f06fdb31b4882ad995e4d19ca7aed    // A single item within the collection.
 
 https://example.com/stores/schema                                     // A schema collection within the service.
-https://example.com/stores/schema/com-example-store-v1.schema.json                // A single item within the collection.
+https://example.com/stores/schema/com-example-store-v1                            // A single item within the collection.
 
 ```
 
@@ -174,7 +174,7 @@ Item: `https://example.com/stores/76cc758e256c438b8e49546e0102b8c8`
   "href": "https://example.com/stores/76cc758e256c438b8e49546e0102b8c8",
   "id": "76cc758e256c438b8e49546e0102b8c8",
   "template": "https://example.com/stores/{id}",
-  "schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+  "schema": "https://example.com/schemas/com-example-store-v1",
   "name": "Alpha",
   "phone": "(425) 555-1212",
   "operations": [
@@ -197,7 +197,7 @@ Representation: `https://example.com/stores/76cc758e256c438b8e49546e0102b8c8/pho
   "href": "https://example.com/stores/76cc758e256c438b8e49546e0102b8c8/phone",
   "id": "76cc758e256c438b8e49546e0102b8c8",
   "template": "https://example.com/stores/{id}/phone",
-  "schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+  "schema": "https://example.com/schemas/com-example-store-v1",
   "phone": "(425) 555-1212"
 }
 ```
@@ -213,7 +213,7 @@ Collection: `https://example.com/stores/all`
   	"href": "https://example.com/stores/76cc758e256c438b8e49546e0102b8c8",
   	"id": "76cc758e256c438b8e49546e0102b8c8",
   	"template": "https://example.com/stores/{id}",
-    "schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+    "schema": "https://example.com/schemas/com-example-store-v1",
     "name": "Alpha",
     "phone": "(425) 555-1212"
   },
@@ -250,6 +250,31 @@ https://example.com/stores/{collection}/{identifier}                   // Single
 https://example.com/stores/{identifier}/{representation}               // Representation of a single item within the base collection.
 https://example.com/stores/{collection}/{identifier}/{representation}  // Representation of a single item within a collection.
 ```
+
+##### Friendly resource name pattern
+
+There are times when resource names should have friendly names readable by humans, for example:
+
+* When the client code chooses the resource name with a `PUT` operation creating a new resource.
+* When the resource is more widely used across client code, for example: JSON Schema.
+
+In order to avoid name collisions a pattern MAY be agreed upon and it is suggested that pattern be, in part, based on how [RFC 1034 Domain Names - Concepts and Facilities](#RFC-1034) works:
+
+```
+{generic top-level domain (gTLD)}
+ -{domain}
+  -{second and lower level domains separated with a -}
+   -{schema name}
+    -{version}
+
+Examples:
+
+  com-example-baseball-equipment-glove-v1
+  org-example-soccer-worldcup-2018-39f6256e
+```
+
+* Services SHOULD refrain from using dots / periods (`.`) in resource names.
+  * Approaching friendly names from the perspective of a file based system may come a desire to append a file name to the end a resource name, for example: `com-example-baseball-equipment-glove-v1`. This may be shortsighted and may appear to be in conflict with the [RFC 7231 Content-Type](https://tools.ietf.org/html/rfc7231#section-3.1.1.5) header should a server decide to make multiple formats available in the future.
 
 ### <a name="hypermedia"></a>Hypermedia as the Engine of Application State
 
@@ -450,7 +475,7 @@ Pagination leverages the [Hypermedia as the Engine of Application State](#hyperm
 
 ```json
 {
-	"schema": "http://example.com/schema/base.schema.json"
+	"schema": "http://example.com/schema/com-example-base-v1"
 }
 ```
 

--- a/guidelines.md
+++ b/guidelines.md
@@ -145,7 +145,7 @@ https://example.com/stores/aisles                                     // A relat
 https://example.com/stores/aisles/c66f06fdb31b4882ad995e4d19ca7aed    // A single item within the collection.
 
 https://example.com/stores/schema                                     // A schema collection within the service.
-https://example.com/stores/schema/com-example-store-v1                            // A single item within the collection.
+https://example.com/stores/schema/com-example-store-v1                // A single item within the collection.
 
 ```
 

--- a/resource-and-representation.md
+++ b/resource-and-representation.md
@@ -27,7 +27,7 @@ The following design and examples are intended to provide a starting point for s
 
 ### <a name="schema-base"></a>Base
 
-* [com-example-base-v1.schema.json](./schema/com-example-base-v1.schema.json)
+* [com-example-base-v1](./schema/com-example-base-v1.schema.json)
 * The base schema provides a starting point for all representations.
 * It is the default schema for all representations.
 * It is the schema used for:
@@ -54,7 +54,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-links"></a>Links
 
-* [com-example-links-v1.schema.json](./schema/com-example-links-v1.schema.json)
+* [com-example-links-v1](./schema/com-example-links-v1.schema.json)
 * A list of links allows related data to be provided to the client which can optionally `GET` each item as so desired.
 
 Name | Type | Format | Description
@@ -66,7 +66,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-operation"></a>Operation
 
-* [com-example-operation-v1.schema.json](./schema/com-example-operation-v1.schema.json)
+* [com-example-operation-v1](./schema/com-example-operation-v1.schema.json)
 
 Name | Type | Format | Description
 -----|------|--------|------------
@@ -78,7 +78,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-store"></a>Store
 
-* [com-example-store-v1.schema.json](./schema/com-example-store-v1.schema.json)
+* [com-example-store-v1](./schema/com-example-store-v1.schema.json)
 * Versioning in the schema name allows the service to revise schema with versioning.
 	* Generally speaking, you can rather easily add new, non-required keys to existing schema without breaking clients as they should be coded in such a way as to ignore keys they don't understand. However, this type of change can be considered a breaking change.
 	* This makes it relatively easy to introduce new schema features or breaking changes (such as new and required keys) without breaking existing clients.
@@ -93,7 +93,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-aisle"></a>Aisle
 
-* [com-example-aisle-v1.schema.json](./schema/com-example-aisle-v1.schema.json)
+* [com-example-aisle-v1](./schema/com-example-aisle-v1.schema.json)
 * See notes on versioning schema in the [store schema](#schema-store).
 
 Name | Type | Format | Description
@@ -107,7 +107,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-error"></a>Error
 
-* [com-example-error-v1.schema.json](./schema/com-example-error-v1.schema.json)
+* [com-example-error-v1](./schema/com-example-error-v1.schema.json)
 * Included here for completeness of the resource model but not currently used in the examples.
 
 Name | Type | Format | Description
@@ -144,7 +144,7 @@ Name | Type | Format | Description
 ```json
 {
 	"href": "https://example.com/stores",
-	"schema": "https://example.com/schemas/com-example-base-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-base-v1",
 	"operations": [
     {
       "rel": "all-stores",
@@ -166,8 +166,8 @@ Name | Type | Format | Description
 * Client code is creating the data.
 * The URI for where to POST comes from the service index: `create-store`.
 * The schema is defined by the server and is used by the client code to specify the data being sent by the client.
-	* `schema` key comes from `com-example-base-v1.schema.json`.
-	* `storeName` and `storePhone` comes from `com-example-store-v1.schema.json`
+	* `schema` key comes from `com-example-base-v1`.
+	* `storeName` and `storePhone` comes from `com-example-store-v1`.
 
 ### Request
 
@@ -175,7 +175,7 @@ Name | Type | Format | Description
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212"
 }
@@ -183,10 +183,10 @@ Name | Type | Format | Description
 
 ### Response
 
-* Note the additional metadata leveraging `com-example-base-v1.schema.json`: `href`, `id` and `template`.
+* Note the additional metadata leveraging `com-example-base-v1`: `href`, `id` and `template`.
 * The client is given the hyperlink for an `operation` on the store for adding an aisle.
 	* This hyperlink is at the heart of Hypermedia as the Engine of Application State.
-	* `operations` is part of `com-example-base-v1.schema.json` and defined in `com-example-operation-v1.schema.json`.
+	* `operations` is part of `com-example-base-v1` and defined in `com-example-operation-v1`.
 * The `POST` occurs on the collection (plural: `stores`).
 * The location of a store is individual (singular: `store`).
 
@@ -197,7 +197,7 @@ Location: https://example.com/store/97b83a735620465cb8a01bf82392336b
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
@@ -228,7 +228,7 @@ Location: https://example.com/store/97b83a735620465cb8a01bf82392336b
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Dairy",
 	"aisleNumber": 10
@@ -244,7 +244,7 @@ Location: https://example.com/aisle/b29e49452ebf4625b44de3034ad99e4d
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Dairy",
 	"aisleNumber": 10,
@@ -267,7 +267,7 @@ Location: https://example.com/aisle/b29e49452ebf4625b44de3034ad99e4d
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Baking",
 	"aisleNumber": 11
@@ -283,7 +283,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Baking",
 	"aisleNumber": 11,
@@ -322,7 +322,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
@@ -371,7 +371,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b/aisledatalinks",
@@ -379,7 +379,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 	"template": "https://example.com/store/{id}/aisledatalinks",
 	"relatedDataLinks": [
 		{
-			"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+			"schema": "https://example.com/schemas/com-example-aisle-v1",
 			"hrefs": [
 				"https://example.com/aisle/b29e49452ebf4625b44de3034ad99e4d",
 				"https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d"
@@ -422,7 +422,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b/aisledata",
@@ -430,7 +430,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 	"template": "https://example.com/store/{id}/aisledata",
 	"relatedData": [
 		{
-			"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+			"schema": "https://example.com/schemas/com-example-aisle-v1",
 			"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 			"aisleName": "Dairy",
 			"aisleNumber": 10,
@@ -446,7 +446,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 			]
 		},
 		{
-			"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+			"schema": "https://example.com/schemas/com-example-aisle-v1",
 			"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 			"aisleName": "Baking",
 			"aisleNumber": 11,

--- a/resource-and-representation.md
+++ b/resource-and-representation.md
@@ -27,7 +27,7 @@ The following design and examples are intended to provide a starting point for s
 
 ### <a name="schema-base"></a>Base
 
-* [base.v1.schema.json](./schema/base.v1.schema.json)
+* [com-example-base-v1.schema.json](./schema/com-example-base-v1.schema.json)
 * The base schema provides a starting point for all representations.
 * It is the default schema for all representations.
 * It is the schema used for:
@@ -54,7 +54,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-links"></a>Links
 
-* [links.v1.schema.json](./schema/links.v1.schema.json)
+* [com-example-links-v1.schema.json](./schema/com-example-links-v1.schema.json)
 * A list of links allows related data to be provided to the client which can optionally `GET` each item as so desired.
 
 Name | Type | Format | Description
@@ -66,7 +66,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-operation"></a>Operation
 
-* [operation.v1.schema.json](./schema/operation.v1.schema.json)
+* [com-example-operation-v1.schema.json](./schema/com-example-operation-v1.schema.json)
 
 Name | Type | Format | Description
 -----|------|--------|------------
@@ -78,7 +78,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-store"></a>Store
 
-* [store.v1.schema.json](./schema/store.v1.schema.json)
+* [com-example-store-v1.schema.json](./schema/com-example-store-v1.schema.json)
 * Versioning in the schema name allows the service to revise schema with versioning.
 	* Generally speaking, you can rather easily add new, non-required keys to existing schema without breaking clients as they should be coded in such a way as to ignore keys they don't understand. However, this type of change can be considered a breaking change.
 	* This makes it relatively easy to introduce new schema features or breaking changes (such as new and required keys) without breaking existing clients.
@@ -93,7 +93,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-aisle"></a>Aisle
 
-* [aisle.v1.schema.json](./schema/aisle.v1.schema.json)
+* [com-example-aisle-v1.schema.json](./schema/com-example-aisle-v1.schema.json)
 * See notes on versioning schema in the [store schema](#schema-store).
 
 Name | Type | Format | Description
@@ -107,7 +107,7 @@ Name | Type | Format | Description
 
 ### <a name="schema-error"></a>Error
 
-* [error.v1.schema.json](./schema/error.v1.schema.json)
+* [com-example-error-v1.schema.json](./schema/com-example-error-v1.schema.json)
 * Included here for completeness of the resource model but not currently used in the examples.
 
 Name | Type | Format | Description
@@ -144,7 +144,7 @@ Name | Type | Format | Description
 ```json
 {
 	"href": "https://example.com/stores",
-	"schema": "https://example.com/schemas/base.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-base-v1.schema.json",
 	"operations": [
     {
       "rel": "all-stores",
@@ -166,8 +166,8 @@ Name | Type | Format | Description
 * Client code is creating the data.
 * The URI for where to POST comes from the service index: `create-store`.
 * The schema is defined by the server and is used by the client code to specify the data being sent by the client.
-	* `schema` key comes from `base.v1.schema.json`.
-	* `storeName` and `storePhone` comes from `store.v1.schema.json`
+	* `schema` key comes from `com-example-base-v1.schema.json`.
+	* `storeName` and `storePhone` comes from `com-example-store-v1.schema.json`
 
 ### Request
 
@@ -175,7 +175,7 @@ Name | Type | Format | Description
 
 ```json
 {
-	"schema": "https://example.com/schemas/store.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212"
 }
@@ -183,10 +183,10 @@ Name | Type | Format | Description
 
 ### Response
 
-* Note the additional metadata leveraging `base.v1.schema.json`: `href`, `id` and `template`.
+* Note the additional metadata leveraging `com-example-base-v1.schema.json`: `href`, `id` and `template`.
 * The client is given the hyperlink for an `operation` on the store for adding an aisle.
 	* This hyperlink is at the heart of Hypermedia as the Engine of Application State.
-	* `operations` is part of `base.v1.schema.json` and defined in `operation.v1.schema.json`.
+	* `operations` is part of `com-example-base-v1.schema.json` and defined in `com-example-operation-v1.schema.json`.
 * The `POST` occurs on the collection (plural: `stores`).
 * The location of a store is individual (singular: `store`).
 
@@ -197,7 +197,7 @@ Location: https://example.com/store/97b83a735620465cb8a01bf82392336b
 
 ```json
 {
-	"schema": "https://example.com/schemas/store.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
@@ -228,7 +228,7 @@ Location: https://example.com/store/97b83a735620465cb8a01bf82392336b
 
 ```json
 {
-	"schema": "https://example.com/schemas/aisle.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Dairy",
 	"aisleNumber": 10
@@ -244,7 +244,7 @@ Location: https://example.com/aisle/b29e49452ebf4625b44de3034ad99e4d
 
 ```json
 {
-	"schema": "https://example.com/schemas/aisle.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Dairy",
 	"aisleNumber": 10,
@@ -267,7 +267,7 @@ Location: https://example.com/aisle/b29e49452ebf4625b44de3034ad99e4d
 
 ```json
 {
-	"schema": "https://example.com/schemas/aisle.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Baking",
 	"aisleNumber": 11
@@ -283,7 +283,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/aisle.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 	"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 	"aisleName": "Baking",
 	"aisleNumber": 11,
@@ -322,7 +322,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/store.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
@@ -371,7 +371,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/store.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b/aisledatalinks",
@@ -379,7 +379,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 	"template": "https://example.com/store/{id}/aisledatalinks",
 	"relatedDataLinks": [
 		{
-			"schema": "https://example.com/schemas/aisle.v1.schema.json",
+			"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 			"hrefs": [
 				"https://example.com/aisle/b29e49452ebf4625b44de3034ad99e4d",
 				"https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d"
@@ -422,7 +422,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 
 ```json
 {
-	"schema": "https://example.com/schemas/store.v1.schema.json",
+	"schema": "https://example.com/schemas/com-example-store-v1.schema.json",
 	"storeName": "Alpha",
 	"storePhone": "(425) 555-1212",
 	"href": "https://example.com/store/97b83a735620465cb8a01bf82392336b/aisledata",
@@ -430,7 +430,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 	"template": "https://example.com/store/{id}/aisledata",
 	"relatedData": [
 		{
-			"schema": "https://example.com/schemas/aisles.v1.schema.json",
+			"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 			"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 			"aisleName": "Dairy",
 			"aisleNumber": 10,
@@ -446,7 +446,7 @@ Location: https://example.com/aisle/a256aabde9884b379f1f99222ebdfe3d
 			]
 		},
 		{
-			"schema": "https://example.com/schemas/aisles.v1.schema.json",
+			"schema": "https://example.com/schemas/com-example-aisle-v1.schema.json",
 			"storeId": "https://example.com/store/97b83a735620465cb8a01bf82392336b",
 			"aisleName": "Baking",
 			"aisleNumber": 11,

--- a/schema/com-example-aisle-v1.schema.json
+++ b/schema/com-example-aisle-v1.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-aisle-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-aisle-v1",
   "title": "Aisle v1 Schema",
   "description": "An individual aisle within a store.",
   "type": "object",
-  "anyOf": [ { "$ref": "https://example.com/schemas/com-example-base-v1.schema.json" } ],
+  "anyOf": [ { "$ref": "https://example.com/schemas/com-example-base-v1" } ],
   "properties": {
     "storeId": {
       "type": "string",

--- a/schema/com-example-aisle-v1.schema.json
+++ b/schema/com-example-aisle-v1.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/aisle.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-aisle-v1.schema.json",
   "title": "Aisle v1 Schema",
   "description": "An individual aisle within a store.",
   "type": "object",
-  "anyOf": [ { "$ref": "https://example.com/schemas/base.v1.schema.json" } ],
+  "anyOf": [ { "$ref": "https://example.com/schemas/com-example-base-v1.schema.json" } ],
   "properties": {
     "storeId": {
       "type": "string",

--- a/schema/com-example-base-v1.schema.json
+++ b/schema/com-example-base-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/base.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-base-v1.schema.json",
   "title": "Base Schema",
   "description": "The base schema provides a starting point for all documents, is the default schema for all documents and is the schema used for metadata.",
   "type": "object",
@@ -28,22 +28,22 @@
     "relatedDataLinks": {
       "type": "array",
       "description": "An array for providing hyperlinks to related data in a parent response.",
-      "items": { "$ref": "https://example.com/schemas/links.v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-links-v1.schema.json" }
     },
     "alternates": {
       "type": "array",
       "description": "An array for providing hyperlinks to alternative representations for this resource.",
-      "items": { "$ref": "https://example.com/schemas/operation.v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-operation-v1.schema.json" }
     },
     "operations": {
       "type": "array",
       "description": "The hypermedia as the engine of application state (HATEOAS) information.",
-      "items": { "$ref": "https://example.com/schemas/operation.v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-operation-v1.schema.json" }
     },
     "errors": {
       "type": "array",
       "description": "The errors collection for when the response code is 4xx.",
-      "items": { "$ref": "https://example.com/schemas/error.v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-error-v1.schema.json" }
     }
   },
   "required": [ "schema" ]

--- a/schema/com-example-base-v1.schema.json
+++ b/schema/com-example-base-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-base-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-base-v1",
   "title": "Base Schema",
   "description": "The base schema provides a starting point for all documents, is the default schema for all documents and is the schema used for metadata.",
   "type": "object",
@@ -28,22 +28,22 @@
     "relatedDataLinks": {
       "type": "array",
       "description": "An array for providing hyperlinks to related data in a parent response.",
-      "items": { "$ref": "https://example.com/schemas/com-example-links-v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-links-v1" }
     },
     "alternates": {
       "type": "array",
       "description": "An array for providing hyperlinks to alternative representations for this resource.",
-      "items": { "$ref": "https://example.com/schemas/com-example-operation-v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-operation-v1" }
     },
     "operations": {
       "type": "array",
       "description": "The hypermedia as the engine of application state (HATEOAS) information.",
-      "items": { "$ref": "https://example.com/schemas/com-example-operation-v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-operation-v1" }
     },
     "errors": {
       "type": "array",
       "description": "The errors collection for when the response code is 4xx.",
-      "items": { "$ref": "https://example.com/schemas/com-example-error-v1.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-error-v1" }
     }
   },
   "required": [ "schema" ]

--- a/schema/com-example-common-v1.schema.json
+++ b/schema/com-example-common-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/common.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-common-v1.schema.json",
   "title": "Common Schema",
   "description": "Shared types used by multiple schemas.",
   "definitions": {

--- a/schema/com-example-common-v1.schema.json
+++ b/schema/com-example-common-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-common-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-common-v1",
   "title": "Common Schema",
   "description": "Shared types used by multiple schemas.",
   "definitions": {

--- a/schema/com-example-error-v1.schema.json
+++ b/schema/com-example-error-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-error-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-error-v1",
   "title": "Error Schema",
   "description": "The error schema provides a way for servers to convey error conditions to clients in the case of HTTP status codes 4xx.",
   "type": "object",
@@ -24,7 +24,7 @@
     "errors": {
       "type": "array",
       "description": "An array of errors. Note: this points to this schema as errors can nest.",
-      "items": { "$ref": "https://example.com/schemas/error.schema.json" }}
+      "items": { "$ref": "https://example.com/schemas/com-example-error-v1" }}
   },
   "required": [ "errorCode", "errorMessage" ]
 }

--- a/schema/com-example-error-v1.schema.json
+++ b/schema/com-example-error-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/error.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-error-v1.schema.json",
   "title": "Error Schema",
   "description": "The error schema provides a way for servers to convey error conditions to clients in the case of HTTP status codes 4xx.",
   "type": "object",

--- a/schema/com-example-links-v1.schema.json
+++ b/schema/com-example-links-v1.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-links-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-links-v1",
   "title": "List Schema",
   "description": "This schema is used for listing out related data via hyperlinks.",
   "type": "object",
-  "anyOf": [ { "$ref": "https://example.com/schemas/base.schema.json" } ],
+  "anyOf": [ { "$ref": "https://example.com/schemas/com-example-base-v1" } ],
   "properties": {
     "hrefs": {
       "type": "array",

--- a/schema/com-example-links-v1.schema.json
+++ b/schema/com-example-links-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/links.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-links-v1.schema.json",
   "title": "List Schema",
   "description": "This schema is used for listing out related data via hyperlinks.",
   "type": "object",

--- a/schema/com-example-operation-v1.schema.json
+++ b/schema/com-example-operation-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-operation-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-operation-v1",
   "title": "Operation Schema",
   "description": "An operation provides the base for Hypermedia as the Engine of Application State",
   "type": "object",

--- a/schema/com-example-operation-v1.schema.json
+++ b/schema/com-example-operation-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/operation.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-operation-v1.schema.json",
   "title": "Operation Schema",
   "description": "An operation provides the base for Hypermedia as the Engine of Application State",
   "type": "object",

--- a/schema/com-example-store-v1.schema.json
+++ b/schema/com-example-store-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/store.v1.schema.json",
+  "href": "https://example.com/schemas/com-example-store-v1.schema.json",
   "title": "Store v1 Schema",
   "description": "A single store for example: grocery store.",
   "type": "object",

--- a/schema/com-example-store-v1.schema.json
+++ b/schema/com-example-store-v1.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/com-example-store-v1.schema.json",
+  "href": "https://example.com/schemas/com-example-store-v1",
   "title": "Store v1 Schema",
   "description": "A single store for example: grocery store.",
   "type": "object",
-  "anyOf": [ { "$ref": "https://example.com/schemas/base.schema.json" } ],
+  "anyOf": [ { "$ref": "https://example.com/schemas/com-example-base-v1" } ],
   "properties": {
     "storeName": { "type": "string" },
     "storePhone": { "type": "string" }

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -1,25 +1,25 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "href": "https://example.com/schemas/template.schema.json",
+  "href": "https://example.com/schemas/template",
   "title": "Template Schema",
   "description": "This template contains many of the major JSON schema types and keywords - use for building other schemas.",
 
   "type": "object",
 
   "allOf": [{
-    "$ref": "base.schema.json"
+    "$ref": "https://example.com/schemas/com-example-base-v1"
   }],
 
   "anyOf": [{
-    "$ref": "base.schema.json"
+    "$ref": "https://example.com/schemas/com-example-base-v1"
   }],
 
   "oneOf": [{
-    "$ref": "base.schema.json"
+    "$ref": "https://example.com/schemas/com-example-base-v1"
   }],
 
   "not": {
-    "$ref": "base.schema.json"
+    "$ref": "https://example.com/schemas/com-example-base-v1"
   },
 
   "comment": "`default` and `enum` are available for all instance types.",
@@ -76,7 +76,7 @@
 
     "keyNameWithDefinitionInternal": { "$ref": "#/definitions/keyNameDefinition" },
 
-    "keyNameWithDefinitionExternal": { "$ref": "common.schema.json#/definitions/dateTime" },
+    "keyNameWithDefinitionExternal": { "$ref": "https://example.com/schemas/common#/definitions/dateTime" },
 
     "keyNameArraySingleItems": {
       "type": "array",
@@ -104,7 +104,7 @@
 
     "keyNameArrayReference": {
       "type": "array",
-      "items": { "$ref": "base.schema.json" }
+      "items": { "$ref": "https://example.com/schemas/com-example-base-v1" }
     },
 
     "keyNameObject": { "type": "object" },


### PR DESCRIPTION
This pull request:

* Documents the resource friendly name pattern.
* Makes changes to all of the resources / examples therein to conform to the pattern.
* In a nutshell, from `base.v1.schema.json` to `com-example-base-v1`.